### PR TITLE
cygwin-system: ignore esbcache extended attribute

### DIFF
--- a/nixos/maintainers/scripts/cygwin/system.nix
+++ b/nixos/maintainers/scripts/cygwin/system.nix
@@ -140,7 +140,10 @@ in
     nixpkgs.hostPlatform = lib.mkDefault "x86_64-cygwin";
 
     nix = {
-      settings.sandbox = false;
+      settings = {
+        sandbox = false;
+        ignored-acls = "user.$kernel.purge.esbcache";
+      };
       package = pkgs.nixVersions.git;
     };
 

--- a/nixos/maintainers/scripts/cygwin/system.nix
+++ b/nixos/maintainers/scripts/cygwin/system.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (pkgs)
+    bash
+    buildEnv
+    coreutils
+    runCommand
+    writeShellScript
+    ;
+
+  nix = config.nix.package;
+
+  sw = buildEnv {
+    name = "cygwin-root";
+
+    paths = config.environment.systemPackages;
+
+    nativeBuildInputs = [
+      ../../../../pkgs/build-support/setup-hooks/make-symlinks-relative.sh
+    ];
+  };
+
+  activate = writeShellScript "activate" ''
+    (
+      export PATH=${
+        lib.makeBinPath [
+          coreutils
+          nix
+        ]
+      }:/bin
+      mkdir -p /nix/var/nix/gcroots
+      ln -sfn /run/current-system /nix/var/nix/gcroots/current-system
+      mkdir -p /run
+      ln -sfn '${lib.getExe bash}' /bin/sh
+      ln -sfn '@out@' /run/current-system
+      ln -sfn /run/current-system/etc /etc
+      if [[ -f /nix-path-registration ]]; then
+        nix-store --load-db < /nix-path-registration
+        rm /nix-path-registration
+      fi
+    )
+  '';
+
+in
+{
+  options = {
+    system.cygwin.toplevel = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+    };
+  };
+
+  imports = [
+    ../../../modules/profiles/minimal.nix
+  ];
+
+  config = {
+    boot = {
+      bcache.enable = false;
+      initrd = {
+        supportedFilesystems = [ ];
+      };
+      kernel.sysctl = lib.mkForce { };
+      loader.grub.enable = false;
+      modprobeConfig.enable = false;
+      supportedFilesystems = [ ];
+    };
+
+    console.enable = false;
+
+    fonts.fontconfig.enable = false;
+
+    # the default requires glibcLocales
+    i18n.supportedLocales = [ ];
+
+    networking = {
+      dhcpcd.enable = false;
+      firewall.enable = false;
+      resolvconf.enable = false;
+    };
+
+    programs = {
+      fuse.enable = false;
+      less.enable = lib.mkForce false;
+      nano.enable = false;
+      ssh.systemd-ssh-proxy.enable = false;
+    };
+
+    security = {
+      pam.enable = false;
+      shadow.enable = false;
+      sudo.enable = false;
+    };
+
+    services = {
+      lvm.enable = false;
+      udev.enable = false;
+    };
+
+    system = {
+      disableInstallerTools = true;
+      # this is needed because tasks/filesystems.nix unconditionally adds
+      # dosfstools, and tasks/filesystems/ext adds e2fsprogs
+      fsPackages = lib.mkForce [ ];
+      # these match the cygwin defaults when "file" is prepended
+      nssDatabases = {
+        passwd = [ "db" ];
+        group = [ "db" ];
+      };
+    };
+
+    systemd = {
+      enable = false;
+      coredump.enable = false;
+    };
+
+    users = {
+      users = lib.mkForce { };
+      groups = lib.mkForce { };
+    };
+
+    environment.corePackages =
+      with pkgs;
+      lib.mkForce [
+        bash
+        coreutils
+        openssh
+        curl
+        config.nix.package
+      ];
+    environment.defaultPackages = lib.mkForce [ ];
+
+    nixpkgs.buildPlatform = lib.mkDefault builtins.currentSystem;
+    nixpkgs.hostPlatform = lib.mkDefault "x86_64-cygwin";
+
+    nix = {
+      settings.sandbox = false;
+      package = pkgs.nixVersions.git;
+    };
+
+    system.cygwin.toplevel = runCommand "cygwin-system" { } ''
+      mkdir "$out"
+      ln -sr "${sw}" "$out"/sw
+      cp "${activate}" "$out"/activate
+      substituteInPlace $out/activate --subst-var-by out "$out"
+      ln -sr "${config.system.build.etc}"/etc $out/etc
+    '';
+  };
+}

--- a/nixos/maintainers/scripts/cygwin/tarball.nix
+++ b/nixos/maintainers/scripts/cygwin/tarball.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (pkgs)
+    bash
+    buildPackages
+    cygwin
+    gnutar
+    lib
+    runCommand
+    writeShellScript
+    writeText
+    ;
+
+  nix = config.nix.package;
+
+  bootScript = writeText "cygwin.ps1" (
+    lib.replaceString "\n" "\r\n" ''
+      $ErrorActionPreference = 'Stop'
+      $bash = "$PSScriptRoot${lib.replaceString "/" "\\" (lib.getBin bash).outPath}\bin\bash.exe"
+      & $bash /nix/var/nix/profiles/system/activate
+      if (!$?) { throw 'activation script failed' }
+      & $bash --login -i $args
+      if (!$?) { exit 1 }
+    ''
+  );
+
+  cygwin1 = lib.getBin cygwin.newlib-cygwin.out + "/bin/cygwin1.dll";
+
+in
+{
+  options.system.cygwin.tarball = lib.mkOption {
+    type = lib.types.package;
+    readOnly = true;
+  };
+
+  config = {
+    environment.etc."profile".text = ''
+      export CYGWIN=winsymlinks=native\ $CYGWIN
+    '';
+
+    system.cygwin = {
+
+      tarball =
+        let
+          install = writeText "install.ps1" (
+            lib.replaceString "\n" "\r\n" ''
+              param ([Parameter(Mandatory=$true)][string]$dir)
+
+              $ErrorActionPreference = 'Stop'
+
+              $_ = mkdir -force $dir
+
+              fsutil file setCaseSensitiveInfo $dir enable
+              if (!$?) { throw 'setCaseSensitiveInfo failed, this may require: Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux' }
+
+              $_ = ni $dir\.test-target
+              try {
+                cmd /c mklink $dir\.test-link $dir\.test-target
+                if (!$?) {
+                  throw 'failed to create symbolic link: developer mode may need to be enabled'
+                }
+              } catch {
+                  throw
+              } finally {
+                  rm $dir\.test-target
+              }
+              rm $dir\.test-link
+
+              $env:CYGWIN = "winsymlinks=native"
+              & $PSScriptRoot\tar -C $dir --force-local -xpf $PSScriptRoot\${config.system.cygwin.tarball.fileName}.tar${config.system.cygwin.tarball.extension}
+              if (!$?) { throw 'failed to extract tarball' }
+            ''
+          );
+
+          system = config.system.cygwin.toplevel;
+        in
+        (pkgs.callPackage ../../../lib/make-system-tarball.nix {
+          # HACK: disable compression
+          compressCommand = "cat";
+          compressionExtension = "";
+
+          contents = [
+            {
+              source = cygwin1;
+              target = "/bin/cygwin1.dll";
+            }
+            {
+              source = bootScript;
+              target = "cygwin.ps1";
+            }
+          ];
+
+          storeContents = [
+            {
+              object = system;
+              symlink = "none";
+            }
+          ];
+
+          extraCommands = buildPackages.writeShellScript "extra-commands.sh" ''
+            chmod -R +w nix
+            mkdir -p tmp nix/var/nix/profiles dev
+            mkdir -m 01777 dev/{shm,mqueue}
+            ln -s "$(realpath -s --relative-to=/nix/var/nix/profiles "${system}")" nix/var/nix/profiles/system
+            find . -type l -print0 | while read -r -d "" f; do
+                symlinkTarget=$(readlink "$f")
+                if [[ "$symlinkTarget"/ != /nix/store* ]]; then
+                    # skip this symlink as it doesn't point to /nix/store
+                    continue
+                fi
+
+                relativeTarget=''${symlinkTarget#/}
+
+                if [ ! -e "$relativeTarget" ]; then
+                    echo "the symlink $f is broken, it points to $relativeTarget (which is missing)"
+                fi
+
+                relativeTarget=$(realpath -s --relative-to=$(dirname "$f") "$relativeTarget")
+
+                echo "changing symlink $f -> $symlinkTarget to $relativeTarget"
+                ln -snf "$relativeTarget" "$f"
+            done
+
+            mkdir -p "$out"/tarball
+            cp "${install}" "$out"/tarball/install.ps1
+            cp "${gnutar}/bin/tar.exe" "$out"/tarball/
+            for dll in "${gnutar}/bin"/*.dll; do
+              if [[ $dll != */cygwin1.dll ]]; then
+                cp "$dll" "$out"/tarball/
+              fi
+            done
+            cp "${cygwin1}" "$out"/tarball/
+          '';
+        });
+    };
+  };
+}

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1637,6 +1637,10 @@ in
 
   options = {
 
+    security.pam.enable = lib.mkEnableOption "enable pam" // {
+      default = true;
+    };
+
     security.pam.package = lib.mkPackageOption pkgs "pam" { };
 
     security.pam.loginLimits = lib.mkOption {
@@ -2235,7 +2239,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkIf config.security.pam.enable {
     assertions = [
       {
         assertion = config.users.motd == "" || config.users.motdFile == null;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -233,6 +233,10 @@ in
 
   options.systemd = {
 
+    enable = mkEnableOption "enable systemd" // {
+      default = true;
+    };
+
     package = mkPackageOption pkgs "systemd" { };
 
     enableStrictShellChecks = mkEnableOption "" // {
@@ -477,7 +481,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = mkIf cfg.enable {
 
     warnings =
       let

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -192,7 +192,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf config.systemd.enable {
     warnings =
       let
         paths = lib.filter (path: path != null && lib.hasPrefix "/etc/tmpfiles.d/" path) (

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -191,7 +191,7 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf config.systemd.enable {
     systemd.additionalUpstreamSystemUnits = [
       "user.slice"
     ];

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -456,6 +456,28 @@ rec {
         )
       );
 
+  cygwinTarball =
+    forMatchingSystems
+      [
+        "x86_64-linux"
+        "aarch64-linux"
+      ]
+      (
+        system:
+
+        hydraJob (
+          (import lib/eval-config.nix {
+            inherit system;
+            modules = [
+              configuration
+              versionModule
+              ./maintainers/scripts/cygwin/system.nix
+              ./maintainers/scripts/cygwin/tarball.nix
+            ];
+          }).config.system.cygwin.tarball
+        )
+      );
+
   # Ensure that all packages used by the minimal NixOS config end up in the channel.
   dummy = forAllSystems (
     system:


### PR DESCRIPTION
Without this I get:

> error: removing extended attribute 'user.$kernel.purge.esbcache'
> from '/nix/store/jcp15vh9v7lfprmncqmwhlzhyh301bgf-unpack/bin/cp.exe':
> Permission denied

This seems to be a kernel-owned attribute and user-mode processes probably shouldn't touch it, which I think is why we're getting "Permission denied" when trying to. There are probably many other attributes (e.g. anything user.$kernel.*) but this is the only one I've found so far.